### PR TITLE
setup_stm: use Zondax manifest

### DIFF
--- a/shared/setup_stm.sh
+++ b/shared/setup_stm.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-TAG_NAME=openstlinux-4.19-thud-mp1-19-10-09
+# Original manifest from ST
+# TAG_NAME=openstlinux-4.19-thud-mp1-19-10-09
+# MANIFEST_URL=https://github.com/STMicroelectronics/oe-manifest.git
+
+# Zondax manifest
+TAG_NAME=zondax-meta-openstlinux-4.19-thud-mp1
+MANIFEST_URL=https://github.com/Zondax/oe-manifest.git
+
 mkdir -p /home/zondax/shared/${TAG_NAME} && cd /home/zondax/shared/${TAG_NAME}
 cd /home/zondax/shared/${TAG_NAME}
-repo init -u https://github.com/STMicroelectronics/oe-manifest.git -b refs/tags/${TAG_NAME}
+repo init -u ${MANIFEST_URL} -b refs/tags/${TAG_NAME} -m default.xml
 repo sync
 
-export DISTRO=openstlinux-weston 
+export DISTRO=openstlinux-weston
 export MACHINE=stm32mp1
 
 source layers/meta-st/scripts/envsetup.sh


### PR DESCRIPTION
Use Zondax manifest instead of ST, which also includes zondax meta
layer.

`Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>`